### PR TITLE
Update cdc-vs-custom-implementation.md

### DIFF
--- a/docs/cdc-vs-custom-implementation.md
+++ b/docs/cdc-vs-custom-implementation.md
@@ -510,7 +510,7 @@ Operational:
 ```python
 # Oracle-specific good fit scenarios
 oracle_scenarios = [
-    "Batch processing is acceptable (hourly/daily updates)",
+    "Batch processing is acceptable (minute/hour/day updates)",
     "Legacy Oracle systems with limited budget for upgrades",
     "Cost-sensitive environments (avoiding Oracle GoldenGate licensing)",
     "Limited Oracle CDC expertise in organization",


### PR DESCRIPTION
Added by minute as an option for background jobs to open options here. Telstra health had theirs run every 30 seconds. You just hold off if it's still running from the last invocation.